### PR TITLE
Fix NPM publish issue

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,6 +17,6 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm install
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+### Unreleased
 
-## [0.1.0] - 2022-03-11
-### Added
+### [0.1.0] - 2022-03-11
+#### Added
 - Initial `useKeypad` hook, utilities, and types
 - Utility function tests
 - Initial project documentation/setup


### PR DESCRIPTION
### Description

Allow GitHub Actions to publish package publicly.

### Checklist

- [ ] `CHANGELOG` has been updated (_if appropriate_)
